### PR TITLE
Fix for issue#49, crash when loading gltf files.

### DIFF
--- a/core/src/main/java/com/google/ar/sceneform/rendering/RenderableInstance.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/RenderableInstance.java
@@ -142,11 +142,6 @@ public class RenderableInstance implements AnimatableModel {
 
             FilamentAsset createdAsset = renderableData.isGltfBinary ? loader.createAssetFromBinary(renderableData.gltfByteBuffer)
                     : loader.createAssetFromJson(renderableData.gltfByteBuffer);
-            if(renderable.asyncLoadEnabled) {
-                renderableData.resourceLoader.asyncBeginLoad(createdAsset);
-            } else {
-                renderableData.resourceLoader.loadResources(createdAsset);
-            }
 
             if (createdAsset == null) {
                 throw new IllegalStateException("Failed to load gltf");
@@ -177,7 +172,12 @@ public class RenderableInstance implements AnimatableModel {
                     Log.e(TAG, "Failed to download data uri " + dataUri, e);
                 }
             }
-            renderableData.resourceLoader.loadResources(createdAsset);
+
+            if(renderable.asyncLoadEnabled) {
+                renderableData.resourceLoader.asyncBeginLoad(createdAsset);
+            } else {
+                renderableData.resourceLoader.loadResources(createdAsset);
+            }
 
             RenderableManager renderableManager = EngineInstance.getEngine().getRenderableManager();
 


### PR DESCRIPTION
Loading a glTF file will throw inside of Filament and not find the associated bin file. https://github.com/ThomasGorisse/sceneform-android-sdk/issues/49

Moving the initial loading of FilamentAsset "createdAsset" to be after renderableData.resourceLoader.addResourceData, to fix an issue when loading gltf and multi file assets. This does not seem to impact loading single file assets such as glb.