### PR TITLE
Limit the update process by an upper fps bound.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ public void onTapPlane(HitResult hitResult, Plane plane, MotionEvent motionEvent
 **[more...](https://thomasgorisse.github.io/sceneform-android-sdk/emulator)**
 
 
+# FPS-Bound
+
+**[documentation...](https://thomasgorisse.github.io/sceneform-android-sdk/fps_bound)**
+
+
 ## Go further
 
 

--- a/core/src/main/java/com/google/ar/sceneform/rendering/Renderer.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/Renderer.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
+
 import android.view.Surface;
 import android.view.SurfaceView;
 import com.google.android.filament.Camera;
@@ -316,7 +317,7 @@ public class Renderer implements UiHelper.RendererCallback {
           synchronized (mirrors) {
             for (Mirror mirror : mirrors) {
               if (mirror.swapChain != null) {
-                renderer.mirrorFrame(
+                renderer.copyFrame(
                     mirror.swapChain,
                     getLetterboxViewport(currentView.getViewport(), mirror.viewport),
                     currentView.getViewport(),

--- a/docs/fps_bound.md
+++ b/docs/fps_bound.md
@@ -1,0 +1,43 @@
+# FPS-Bound
+
+### Upper-Bound
+
+The Update-Rate of the rendering is limited through the used camera config of ARCore. For most Smartphones it is 30 fps and for the Pixel Smartphones it is 60 fps. The user can manually change this value *(you should know what you are doing)*.
+
+```java
+@Override
+public void onViewCreated(ArFragment arFragment, ArSceneView arSceneView) {
+    arSceneView.setMaxFramesPerSeconds([int])
+}
+```
+
+> The default value is **60**.
+
+
+
+### Further adjustments
+
+The Upper-Bound can be further adjusted if needed. To do so a Frame-Rate-Factor can be set. 
+
+```java
+@Override
+public void onViewCreated(ArFragment arFragment, ArSceneView arSceneView) {
+    arSceneView.setFrameRateFactor(SceneView.FrameRate.FULL)
+}
+```
+
+Three different factor values are available:
+
+- FULL (1)
+- HALF (2)
+- THIRD (3)
+
+The Frame-Rate-Factor divides the Upper-Bound to further reduce the maximum allowed Frame-Rate.
+
+```
+60/FULL = 60
+60/HALF = 30
+60/THIRD = 20
+```
+
+> The default value for the Frame-Rate-Factor is **FULL**

--- a/samples/gltf/src/main/java/com/google/ar/sceneform/samples/gltf/MainActivity.java
+++ b/samples/gltf/src/main/java/com/google/ar/sceneform/samples/gltf/MainActivity.java
@@ -20,6 +20,7 @@ import com.google.ar.core.Session;
 import com.google.ar.sceneform.AnchorNode;
 import com.google.ar.sceneform.ArSceneView;
 import com.google.ar.sceneform.Node;
+import com.google.ar.sceneform.SceneView;
 import com.google.ar.sceneform.Sceneform;
 import com.google.ar.sceneform.math.Vector3;
 import com.google.ar.sceneform.rendering.EngineInstance;
@@ -93,6 +94,9 @@ public class MainActivity extends AppCompatActivity implements
                             .build(EngineInstance.getEngine().getFilamentEngine())
             );
         }
+
+        // Fine adjust the maximum frame rate
+        arSceneView.setFrameRateFactor(SceneView.FrameRate.FULL);
     }
 
     public void loadModels() {


### PR DESCRIPTION
* The upper bound is set by the used camera config. This value can in
theory also be set by the user

```java
sceneView.setMaxFramesPerSeconds([int])
```

* The default value is **60**
* The user can fine adjust the upper bound by a FrameRate-Factor

```java
@Override
public void onViewCreated(ArFragment arFragment, ArSceneView arSceneView) {
    arSceneView.setFrameRateFactor(SceneView.FrameRate.FULL)
}
```

* Three different factor values are available
  * FULL  (1)
  * HALF  (2)
  * THIRD (3)
* The upper bound is divided by the FrameRate-Factor
* The default value for the FrameRate-Factor is **FULL**